### PR TITLE
Fix URLs parts in external sources

### DIFF
--- a/src/streams/response.js
+++ b/src/streams/response.js
@@ -61,7 +61,7 @@ ResponseWriter.prototype._write = function(image){
   if (image.modifiers.action === 'json'){
     if (this.shouldCacheResponse()){
       this.response.set({
-        'Cache-Control':  'public',
+        'Cache-Control':  'public, max-age=' + env.JSON_EXPIRY,
         'Expires':        this.expiresIn(env.JSON_EXPIRY),
         'Last-Modified':  (new Date(1000)).toGMTString(),
         'Vary':           'Accept-Encoding'
@@ -76,7 +76,7 @@ ResponseWriter.prototype._write = function(image){
 
   if (this.shouldCacheResponse()){
     this.response.set({
-      'Cache-Control':  'public',
+      'Cache-Control':  'public, max-age=' + image.expiry,
       'Expires':        this.expiresIn(image.expiry),
       'Last-Modified':  (new Date(1000)).toGMTString(),
       'Vary':           'Accept-Encoding'

--- a/src/streams/sources/external.js
+++ b/src/streams/sources/external.js
@@ -43,6 +43,13 @@ External.prototype._read = function(){
     return this.push(null);
   }
 
+  // Encode image path parts - encode special characters ex. UTF8 chars, space, ...
+  // decodeURI is in Image.prototype.parseUrl
+  this.image.path = this.image.path
+    .split('/')
+    .map(function(part) { return encodeURI(part); })
+    .join('/');    
+
   url = this.prefix + '/' + this.image.path;
 
   this.image.log.time(this.key);


### PR DESCRIPTION
Server return code 500 when URL has encoded special characters (ex. UTF8 chars).

Example URL:
http://bir.i.bt.no/ebtkundeportal-w348/4/2015/10/Fotolia_43540107_L%C2%A9-davis-568x262.jpg

It happens because `Image.prototype.parseUrl` decode path:
`this.path = decodeURI(this.path);`
https://github.com/wjordan/image-resizer/blob/master/src/image.js#L104
